### PR TITLE
Updated correct EPROCESS offsets for Win10 build 14393

### DIFF
--- a/HandleMaster/src/dyn_data.cpp
+++ b/HandleMaster/src/dyn_data.cpp
@@ -60,9 +60,9 @@ namespace dyn_data
       case 14393:
         os_version = win10_au;
         offset_directorytable = 0x028;
-        offset_process_id = 0x2E0;
-        offset_process_links = 0x2E8;
-        offset_object_table = 0x418;
+        offset_process_id     = 0x2E8;
+        offset_process_links  = 0x2F0;
+        offset_object_table   = 0x418;
         break;
       case 15063:
         os_version = win10_cu;


### PR DESCRIPTION
Windows 10 Anniversary update did not change the EPROCESS structure from the orignal Windows 10 version, only the latest Creators update did.